### PR TITLE
Personal messages

### DIFF
--- a/src/ButtonThread.cpp
+++ b/src/ButtonThread.cpp
@@ -186,6 +186,8 @@ int32_t ButtonThread::runOnce()
         switch (btnEvent) {
         case BUTTON_EVENT_PRESSED: {
             LOG_BUTTON("press!");
+            // Mark user interaction for LED notification system
+            setUserInteracted();
             // If a nag notification is running, stop it and prevent other actions
             if (moduleConfig.external_notification.enabled && (externalNotificationModule->nagCycleCutoff != UINT32_MAX)) {
                 externalNotificationModule->stopNow();
@@ -219,6 +221,8 @@ int32_t ButtonThread::runOnce()
 
         case BUTTON_EVENT_DOUBLE_PRESSED: {
             LOG_BUTTON("Double press!");
+            // Mark user interaction for LED notification system
+            setUserInteracted();
 #ifdef ELECROW_ThinkNode_M1
             digitalWrite(PIN_EINK_EN, digitalRead(PIN_EINK_EN) == LOW);
             break;
@@ -229,6 +233,8 @@ int32_t ButtonThread::runOnce()
 
         case BUTTON_EVENT_MULTI_PRESSED: {
             LOG_BUTTON("Mulitipress! %hux", multipressClickCount);
+            // Mark user interaction for LED notification system
+            setUserInteracted();
             switch (multipressClickCount) {
 #if HAS_GPS && !defined(ELECROW_ThinkNode_M1)
             // 3 clicks: toggle GPS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,7 +302,7 @@ static bool userHasInteractedSinceLastMessage = false;
 
 /**
  * Personalized LED blinker that shows message notifications like a badge
- * Slow blink (50/50 duty) for private messages, fast short blink (20/80 duty) for public messages
+ * Slow blink (50/50 duty) for private messages, fast short blink (1/60 duty) for public messages
  * LED off if user has interacted since last message or other conditions not met
  */
 static int32_t ledBlinkerPersonalized()

--- a/src/main.h
+++ b/src/main.h
@@ -93,9 +93,6 @@ void scannerToSensorsMap(const std::unique_ptr<ScanI2CTwoWire> &i2cScanner, Scan
 
 // LED notification state management functions
 void setUserInteracted();
-void setPrivateMessageReceived();
-void setPublicMessageReceived();
-void clearMessageNotifications();
 
 // We default to 4MHz SPI, SPI mode 0
 extern SPISettings spiSettings;

--- a/src/main.h
+++ b/src/main.h
@@ -91,5 +91,11 @@ void scannerToSensorsMap(const std::unique_ptr<ScanI2CTwoWire> &i2cScanner, Scan
                          meshtastic_TelemetrySensorType sensorType);
 #endif
 
+// LED notification state management functions
+void setUserInteracted();
+void setPrivateMessageReceived();
+void setPublicMessageReceived();
+void clearMessageNotifications();
+
 // We default to 4MHz SPI, SPI mode 0
 extern SPISettings spiSettings;

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -154,6 +154,10 @@ class MeshService
 
     uint32_t GetTimeSinceMeshPacket(const meshtastic_MeshPacket *mp);
 
+    /// Check for unread text messages in the queue
+    /// Returns: 0 = no messages, 1 = private messages, 2 = public messages
+    int checkUnreadMessages();
+
   private:
 #if HAS_GPS
     /// Called when our gps position has changed - updates nodedb and sends Location message out into the mesh

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -477,10 +477,6 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             // Encapsulate as a FromRadio packet
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_packet_tag;
             fromRadioScratch.packet = *packetForPhone;
-            
-            // Clear LED message notifications when phone retrieves messages
-            clearMessageNotifications();
-            
             releasePhonePacket();
         }
         break;

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -477,6 +477,10 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             // Encapsulate as a FromRadio packet
             fromRadioScratch.which_payload_variant = meshtastic_FromRadio_packet_tag;
             fromRadioScratch.packet = *packetForPhone;
+            
+            // Clear LED message notifications when phone retrieves messages
+            clearMessageNotifications();
+            
             releasePhonePacket();
         }
         break;

--- a/src/modules/TextMessageModule.cpp
+++ b/src/modules/TextMessageModule.cpp
@@ -4,6 +4,7 @@
 #include "PowerFSM.h"
 #include "buzz.h"
 #include "configuration.h"
+#include "main.h"
 TextMessageModule *textMessageModule;
 
 ProcessMessage TextMessageModule::handleReceived(const meshtastic_MeshPacket &mp)
@@ -16,6 +17,17 @@ ProcessMessage TextMessageModule::handleReceived(const meshtastic_MeshPacket &mp
     // Keep a copy of the most recent text message.
     devicestate.rx_text_message = mp;
     devicestate.has_rx_text_message = true;
+
+    // Update LED notification state based on message type
+    if (mp.to == nodeDB->getNodeNum()) {
+        // Private message directed specifically to us
+        setPrivateMessageReceived();
+        LOG_DEBUG("Private message received, LED notification enabled");
+    } else if (mp.to == NODENUM_BROADCAST || mp.to == NODENUM_BROADCAST_NO_LORA) {
+        // Public broadcast message
+        setPublicMessageReceived();
+        LOG_DEBUG("Public message received, LED notification enabled");
+    }
 
     powerFSM.trigger(EVENT_RECEIVED_MSG);
     notifyObservers(&mp);

--- a/src/modules/TextMessageModule.cpp
+++ b/src/modules/TextMessageModule.cpp
@@ -4,7 +4,6 @@
 #include "PowerFSM.h"
 #include "buzz.h"
 #include "configuration.h"
-#include "main.h"
 TextMessageModule *textMessageModule;
 
 ProcessMessage TextMessageModule::handleReceived(const meshtastic_MeshPacket &mp)
@@ -17,17 +16,6 @@ ProcessMessage TextMessageModule::handleReceived(const meshtastic_MeshPacket &mp
     // Keep a copy of the most recent text message.
     devicestate.rx_text_message = mp;
     devicestate.has_rx_text_message = true;
-
-    // Update LED notification state based on message type
-    if (mp.to == nodeDB->getNodeNum()) {
-        // Private message directed specifically to us
-        setPrivateMessageReceived();
-        LOG_DEBUG("Private message received, LED notification enabled");
-    } else if (mp.to == NODENUM_BROADCAST || mp.to == NODENUM_BROADCAST_NO_LORA) {
-        // Public broadcast message
-        setPublicMessageReceived();
-        LOG_DEBUG("Public message received, LED notification enabled");
-    }
 
     powerFSM.trigger(EVENT_RECEIVED_MSG);
     notifyObservers(&mp);


### PR DESCRIPTION
## Add personalized LED notifications for unread messages

Implements a smart LED notification system that acts like a smartphone badge for unread messages on CLIENT and CLIENT_MUTE devices.

### Features

- __Slow blink (500ms on/off)__ for private messages directed to the device
- __Quick blip (50ms on, 3s off)__ for public broadcast messages
- __Power-aware__: Only shows notifications when on external power (charging/USB)
- __User interaction aware__: Notifications clear when user presses any button
- __Queue-based detection__: Uses existing message queue as source of truth

### Implementation

- Added `checkUnreadMessages()` method to MeshService for queue inspection
- Modified `ledBlinkerPersonalized()` to use return-based timing (cleaner than static variables)
- Integrated with ButtonThread to track user interaction via `setUserInteracted()`
- Self-clearing: notifications automatically stop when phone retrieves messages

### Behavior

LED notifications only appear when ALL conditions are met:

1. Device role is CLIENT or CLIENT_MUTE
2. Device has external power
3. User hasn't interacted since last message
4. Unread text messages exist in queue

Private messages take priority over public messages. The distinctive blink patterns make it easy to distinguish message types while being power-efficient.
